### PR TITLE
WR385863 Fixed activity status in download

### DIFF
--- a/classes/local/entities/coursemodules.php
+++ b/classes/local/entities/coursemodules.php
@@ -135,7 +135,7 @@ class coursemodules extends base {
         // Determine which user to use within the user specific columns - use $PAGE->context if user context or global $USER.
         $userid = $USER->id;
         if ($PAGE->context->contextlevel == CONTEXT_USER) {
-            $userid = $PAGE->context->instanceid;
+            $userid = local_ace_get_user_helper();
         }
 
         $cmalias = $this->get_table_alias('course_modules');


### PR DESCRIPTION
Hi,
This should fix the student's engagement's activity status field being 0 when downloaded in the export.  
Regards,
Sumaiya