### PR TITLE
local_ace: Fix error in custom report database source local_ace users…

### DIFF
--- a/classes/local/entities/userentity.php
+++ b/classes/local/entities/userentity.php
@@ -92,6 +92,7 @@ class userentity extends base {
      * @return column[]
      */
     protected function get_all_columns(): array {
+	global $PAGE;
         $course = local_ace_get_course_helper();
         if (!empty($course)) {
             $courseid = $course->id;
@@ -129,7 +130,7 @@ class userentity extends base {
                                   ON {$this->logstorealias3}.courseid = {$coursealias}.id
                                  AND {$this->logstorealias3}.userid = {$usertablealias}.id";
 
-        if (method_exists($this, 'add_selectable_column')) {
+        if (method_exists($this, 'add_selectable_column') && isset($PAGE->context)) {
             $this->add_selectable_column('u');
         }
 

--- a/classes/local/filters/myenrolledcourses.php
+++ b/classes/local/filters/myenrolledcourses.php
@@ -93,15 +93,19 @@ class myenrolledcourses extends \core_reportbuilder\local\filters\base {
         }
 
         $courses = enrol_get_my_courses('id', null, 0, [], $allaccessible);
-        $courseids = array_keys($courses);
+        // This user is not enrolled in any course. Ignore filter.
+        if (empty($courses)) {
+            return ['', []];
+        } else {
+            $courseids = array_keys($courses);
 
-        $fieldsql = $this->filter->get_field_sql();
-        $params = $this->filter->get_field_params();
+            $fieldsql = $this->filter->get_field_sql();
+            $params = $this->filter->get_field_params();
 
-        $paramprefix = database::generate_param_name() . '_';
-        [$courseselect, $courseparams] = $DB->get_in_or_equal($courseids, SQL_PARAMS_NAMED, $paramprefix);
-
-        return ["{$fieldsql} $courseselect", array_merge($params, $courseparams)];
+            $paramprefix = database::generate_param_name() . '_';
+            [$courseselect, $courseparams] = $DB->get_in_or_equal($courseids, SQL_PARAMS_NAMED, $paramprefix);
+            return ["{$fieldsql} $courseselect", array_merge($params, $courseparams)];
+        }
     }
 
     /**

--- a/locallib.php
+++ b/locallib.php
@@ -586,6 +586,12 @@ function local_ace_get_user_courses(int $userid, ?int $courseid = 0): array {
     $period = get_config('local_ace', 'displayperiod');
 
     $activeenrolledcourses = enrol_get_users_courses($userid, true);
+    if (empty($activeenrolledcourses)) {
+        return array(
+            0 => 0,
+            1 => 0,
+        );
+    }
     list($sqlin, $params) = $DB->get_in_or_equal(array_keys($activeenrolledcourses), SQL_PARAMS_NAMED);
 
     // Get courses where analytics data exists.
@@ -1204,7 +1210,7 @@ function local_ace_get_course_helper() {
             if ($PAGE->context->contextlevel == CONTEXT_USER) {
                 // Get list of allowed courses.
                 list($courseid, $courses) = local_ace_get_user_courses($PAGE->context->instanceid, 0);
-                if (count($courses) == 1) {
+                if (isset($courses) && count($courses) == 1) {
                     return get_course($courseid);
                 }
             }
@@ -1234,7 +1240,7 @@ function local_ace_get_course_helper() {
                     if ($context->contextlevel == CONTEXT_USER) {
                         // Get list of allowed courses.
                         list($courseid, $courses) = local_ace_get_user_courses($context->instanceid, 0);
-                        if (count($courses) == 1) {
+                        if (isset($courses) && count($courses) == 1) {
                             return get_course($courseid);
                         }
                     }


### PR DESCRIPTION
Hi,

Fixes errors when dashboard with local_ace report or graphs is being viewed with system context level or when context level is not set. 

Activity ACE Dashboard
- Error message when degugging on from reports block
Coding error detected, it must be fixed by a programmer: $PAGE-&gt;context was not set. You may have forgotten to call require_login() or $PAGE-&gt;set_context()

Course ACE Dashboard
- When contextid not mentioned or when editing the dashboard from main settings page
document.querySelector(...) is null

My ACE Dashboard
- When contextid not mentioned or when editing the dashboard from main settings page
Coding error detected, it must be fixed by a programmer: moodle_database::get_in_or_equal() does not accept empty arrays
custom report local/ace/classes/reportbuilder/datasource/users.php

Regards,
Sumaiya